### PR TITLE
Add missing banana sizes popup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from 'react';
+import { BananaSizesDialog } from "./components/BananaSizesDialog";
 
 export default function App() {
   const [bananaCount, setBananaCount] = useState(3);
@@ -323,10 +324,7 @@ export default function App() {
               />
               <span className="weight-unit">g</span>
             </div>
-            
-            <div className="help-link">
-              🔍 Banana sizes
-            </div>
+            <BananaSizesDialog />
           </div>
 
           {inputError && (

--- a/src/components/BananaSizesDialog.tsx
+++ b/src/components/BananaSizesDialog.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle
+} from './ui/dialog';
+
+const sizeData = [
+  { bananas: 1, weight: 120 },
+  { bananas: 2, weight: 240 },
+  { bananas: 3, weight: 360 },
+  { bananas: 4, weight: 480 },
+  { bananas: 5, weight: 600 },
+  { bananas: 6, weight: 720 },
+  { bananas: 7, weight: 840 },
+  { bananas: 8, weight: 960 },
+  { bananas: 9, weight: 1080 },
+  { bananas: 10, weight: 1200 }
+];
+
+export const BananaSizesDialog: React.FC = () => {
+  return (
+    <Dialog>
+      <DialogTrigger className="help-link">🔍 Banana sizes</DialogTrigger>
+      <DialogContent className="max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Banana Weights</DialogTitle>
+        </DialogHeader>
+        <p className="mb-4 text-sm text-gray-600">
+          A medium banana is about 120g. Here is a quick reference for converting bananas to weight.
+        </p>
+        <table className="w-full text-sm border-collapse">
+          <thead>
+            <tr>
+              <th className="border-b px-2 py-1 text-left">Bananas</th>
+              <th className="border-b px-2 py-1 text-left">Mashed weight (g)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sizeData.map((row) => (
+              <tr key={row.bananas}>
+                <td className="border-b px-2 py-1">{row.bananas}</td>
+                <td className="border-b px-2 py-1">{row.weight}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </DialogContent>
+    </Dialog>
+  );
+};


### PR DESCRIPTION
## Summary
- add a BananaSizesDialog component
- hook BananaSizesDialog to the Banana sizes help link

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_6881819e2c6c8331a648ee097d872173